### PR TITLE
rails 7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
 jobs:
+
   # SQLITE
   sqlite:
     runs-on: ubuntu-latest
@@ -27,7 +28,7 @@ jobs:
 
           # Rails 7 requires Ruby 2.7 or higher
           - ruby: '2.6'
-            gemfile: rails_main
+            gemfile: [ rails_main, rails_7_0 ]
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       BUNDLE_PATH_RELATIVE_TO_CWD: true
@@ -65,7 +66,7 @@ jobs:
 
           # Rails 7 requires Ruby 2.7 or higher
           - ruby: '2.6'
-            gemfile: rails_main
+            gemfile: [ rails_main, rails_7_0 ]
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       BUNDLE_PATH_RELATIVE_TO_CWD: true
@@ -118,7 +119,7 @@ jobs:
 
           # Rails 7 requires Ruby 2.7 or higher
           - ruby: '2.6'
-            gemfile: rails_main
+            gemfile: [ rails_main, rails_7_0 ]
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       BUNDLE_PATH_RELATIVE_TO_CWD: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           - rails_5_2
           - rails_6_0
           - rails_6_1
+          - rails_7_0
           - rails_main
         exclude:
           - ruby: '3.0'
@@ -56,6 +57,7 @@ jobs:
           - rails_5_2
           - rails_6_0
           - rails_6_1
+          - rails_7_0
           - rails_main
         exclude:
           - ruby: '3.0'
@@ -108,6 +110,7 @@ jobs:
           - rails_5_2
           - rails_6_0
           - rails_6_1
+          - rails_7_0
           - rails_main
         exclude:
           - ruby: '3.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ on:
     branches:
       - master
 jobs:
-
   # SQLITE
   sqlite:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: ['2.6', '2.7', '3.0']
         gemfile:
@@ -28,7 +28,10 @@ jobs:
 
           # Rails 7 requires Ruby 2.7 or higher
           - ruby: '2.6'
-            gemfile: [ rails_main, rails_7_0 ]
+            gemfile: rails_main
+
+          - ruby: '2.6'
+            gemfile: rails_7_0
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       BUNDLE_PATH_RELATIVE_TO_CWD: true
@@ -52,6 +55,7 @@ jobs:
   mysql:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: ['2.6', '2.7', '3.0']
         gemfile:
@@ -66,7 +70,10 @@ jobs:
 
           # Rails 7 requires Ruby 2.7 or higher
           - ruby: '2.6'
-            gemfile: [ rails_main, rails_7_0 ]
+            gemfile: rails_main
+
+          - ruby: '2.6'
+            gemfile: rails_7_0
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       BUNDLE_PATH_RELATIVE_TO_CWD: true
@@ -105,6 +112,7 @@ jobs:
   postgres:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: ['2.6', '2.7', '3.0']
         gemfile:
@@ -119,7 +127,10 @@ jobs:
 
           # Rails 7 requires Ruby 2.7 or higher
           - ruby: '2.6'
-            gemfile: [ rails_main, rails_7_0 ]
+            gemfile: rails_7_0
+
+          - ruby: '2.6'
+            gemfile: rails_main
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       BUNDLE_PATH_RELATIVE_TO_CWD: true

--- a/Appraisals
+++ b/Appraisals
@@ -1,4 +1,4 @@
-{ '5_2' => '5.2.0', '6_0' => '6.0.0', '6_1' => '6.1.0' }.each do |rails, version|
+{ '5_2' => '5.2.0', '6_0' => '6.0.0', '6_1' => '6.1.0', '7_0' => '7.0.0' }.each do |rails, version|
   appraise "rails-#{rails}" do
     gem "rails", "~> #{version}"
   end
@@ -7,4 +7,3 @@ end
 appraise "rails-main" do
   gem "rails", github: "rails/rails", branch: "main"
 end
-

--- a/awesome_nested_set.gemspec
+++ b/awesome_nested_set.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activerecord', '>= 4.0.0', '< 7.1'
 
   s.add_development_dependency 'appraisal'
-  s.add_development_dependency 'combustion', '>= 0.5.2', '< 0.5.5'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-nav'

--- a/awesome_nested_set.gemspec
+++ b/awesome_nested_set.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.summary = 'An awesome nested set implementation for Active Record'
   s.license = 'MIT'
 
-  s.required_ruby_version = '>= 2.7.0'
+  s.required_ruby_version = '>= 2.0.0'
 
   s.add_runtime_dependency 'activerecord', '>= 4.0.0', '< 7.1'
 

--- a/awesome_nested_set.gemspec
+++ b/awesome_nested_set.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_runtime_dependency 'activerecord', '>= 4.0.0', '< 7.0'
+  s.add_runtime_dependency 'activerecord', '>= 4.0.0', '< 7.1'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'combustion', '>= 0.5.2', '< 0.5.5'

--- a/awesome_nested_set.gemspec
+++ b/awesome_nested_set.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.summary = 'An awesome nested set implementation for Active Record'
   s.license = 'MIT'
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   s.add_runtime_dependency 'activerecord', '>= 4.0.0', '< 7.1'
 

--- a/awesome_nested_set.gemspec
+++ b/awesome_nested_set.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-nav'
-  s.add_development_dependency 'rake', '~> 10'
+  s.add_development_dependency 'rake', '~> 12'
   s.add_development_dependency 'rspec-rails', '~> 4.0.0'
 
   s.cert_chain = [File.expand_path('certs/parndt.pem', __dir__)]

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", github: "rails/rails", branch: "main"
+gem "rails", "~> 7.0.0"
 
 platforms :ruby do
   gem "sqlite3"


### PR DESCRIPTION
- Add support for Rails 7
- Add Rails 7 to github action CI flow
- Update dependency to rake ~> 12
- Rails 7 requires ruby >= 2.7.0
- revert required ruby_version
- Only run rails 7 and rails main on ruby >= 2.7
- Fix specs and rework database loading
